### PR TITLE
0004: Fix the text input box having a newline after sending a msg

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -465,6 +465,7 @@
             if (event.shiftKey) {
               return;
             } else {
+              event.preventDefault();
               sendMessage(MSG_TYPES.WITH_HISTORY);
             }
           }


### PR DESCRIPTION
Fix for #4 

This may not be the best fix, but it works.
I dont know any of the languages here, but my guess is its something to do with the default behavior of enter = new line, conflicting with something? Idk.