### PR TITLE
Containerise (or containerize)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Don't include potentially large working directories in the image
+.github/
+.vscode/
+node_modules/

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,30 @@
+# Stage 1: Build the front-end app
+# Ideally this should be pinned to a specific version tag
+FROM node:slim AS build
+
+WORKDIR /app
+
+# Copy package.json and package-lock.json first to take advantage of caching
+COPY package*.json ./
+
+# Install dependencies, ensuring we use the exact same versions as in package-lock.json
+RUN npm ci
+
+# Copy the rest of the application code (.dockerignore prevents copying node_modules, etc.)
+COPY . .
+
+# Build the front-end app, outputting to the `./dist` directory
+RUN npm run build
+
+# Stage 2: Serve the built app using Nginx
+# Ideally this should be pinned to a specific version tag
+FROM nginx:alpine-slim
+
+# Copy the built app from the previous stage to the Nginx default HTML directory
+COPY --from=build --chown=nobody:nobody /app/dist /usr/share/nginx/html
+
+# Expose port 80 for Nginx
+EXPOSE 80
+
+# Start Nginx when the container runs
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary

This pull request includes changes for a production container build that can be used by `docker` or `podman`.

## Prior Work

An outstanding PR from March/April 2023 (#7) includes a `Dockerfile` for a development build.

This PR does not conflict with the previous work. 

The image for PR #7 is around 245M, this one is about 13.6M (5.6M compressed)

The `.dockeringnore` file included with this PR may reduce the size of the image built by PR #7 since that image also 
includes `.git/`, `.vscode/` and anything else that may be floating around the directory.

## Changes

Here are the main changes made in this PR:

- Add a `.dockerignore` to ensure unused directories are not copied into images
- Add a `Dockerfile.prod` to build a production container

## Container Details

The build works by utilising a multi-stage build. The first stage is used to build the front-end code using a node container, 
and the second layer is an nginx container that serves the compiled front-end code. There are no node artifacts left in the 
final build container. The container exposes the nginx port 80 binding.

### Building the Container
To build the container, use:

```
docker build -t chatgpt -f Dockerfile.prod .
```

If you are using `podman` simply replace `docker` with `podman`

### Running the Container

There are multiple ways to run a container. For a clean quickstart method, use:

```
docker run --rm chatgpt
```

If you are using `podman` simply replace `docker` with `podman`

You can use `CTRL-C` to quit, the `--rm` option will remove the container once it stops running.

## Additional Information

An image I've already built for myself is available at https://hub.docker.com/r/exzyle/chatgpt/tags.

You can use it by:

```
docker pull exzyle/chatgpt:20240108000
docker run --rm exzyle/chatgpt:20240108000
```
